### PR TITLE
Add seaborn-base to run_constrained

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ build:
     - summarytgr = pesummary.cli.summarytgr:main
     - summaryversion = pesummary.cli.summaryversion:main
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -67,15 +67,26 @@ requirements:
     - tqdm >=4.44.0
   run_constrained:
     - bilby >=1.1.1
+    - seaborn-base >=0.12.2,<0.13.0a0
 
 test:
   requires:
-    - nbformat
     - pip
     - python {{ python_min }}
+    # pesummary's extra test requirements
+    # (these should be left unconstrainted to ensure that the above metadata
+    #  does the job of constraining them appropriately)
+    - bilby
+    - coloredlogs
+    - gitpython
+    - gwosc
+    - ligo.skymap
+    - nbformat
+    - pycbc
+    - seaborn-base
   commands:
     # check requirements
-    - python -m pip check pesummary
+    - python -m pip check
     - python -m pip show pesummary
     # run basic sanity checks
     - summarytest --type imports


### PR DESCRIPTION
This PR adds `seaborn-base` to `requirements:run_constrained`.

Avoids https://git.ligo.org/lscsoft/pesummary/-/issues/334.

Also add a most of the 'extra' extra as test requirements, to check that the run and run_constrained versions are correct.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
