### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   python:
     entry_points:
       - summaryclassification = pesummary.cli.summaryclassification:main
@@ -83,7 +83,7 @@ tests:
         - nbformat
         - pip
         - pycbc
-        - python ${{ python_min }}
+        - python ${{ python_min }}.*
         - seaborn-base
     script:
       - python -m pip check


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{ python_min }}` to make them valid match specs.